### PR TITLE
bump socket.io browser/client version to 2.2

### DIFF
--- a/python-flask-socketio-server/README.md
+++ b/python-flask-socketio-server/README.md
@@ -54,11 +54,7 @@ See no reason that webserver itself couldn't run on a Raspberry Pi, just haven't
 future ideas
 ============
 
-1.	Add websockets support
-	-	should be simple matter of adding `eventlet` lib?
-2.	Add support or example for displaying to character LCD display
-3.	Add playback controls?
-4.	add smarter player state observation / display
+Moved to [issues](https://github.com/idcrook/shairport-sync-mqtt-display/issues)
 
 inspired by
 ===========

--- a/python-flask-socketio-server/templates/main.html
+++ b/python-flask-socketio-server/templates/main.html
@@ -10,10 +10,7 @@
   <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
-  <!-- according to flask-socketio tested with socketio 1.3 and 1.4 -->
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.8/socket.io.min.js"></script>
-
-
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"></script>
   <script type="text/javascript" charset="utf-8">
    $(document).ready(function() {
      var socket = io.connect('http://' + document.domain + ':' + location.port);


### PR DESCRIPTION
 - still works in iOS 9 Safari