### PR TITLE
do not move to flask 3.x

### DIFF
--- a/python-flask-socketio-server/requirements.txt
+++ b/python-flask-socketio-server/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask<3
 Flask-SocketIO==5.1.2
 paho-mqtt
 pyyaml


### PR DESCRIPTION
Flask 3.0 was released end of Spetember 2023. stay away from it.

Fixes #49 