### PR TITLE
Cover gap between songs + volume bar

### DIFF
--- a/python-flaschen-taschen/app.py
+++ b/python-flaschen-taschen/app.py
@@ -194,7 +194,7 @@ def clear_display():
     flaschenSendThumbnailImage(flaschen_client, image)
 
 def on_message(client, userdata, message, properties=None):
-    global volume_clear_timer
+    global volume_clear_timer, display_clear_timer
     topic = message.topic
     payload = message.payload
 


### PR DESCRIPTION
The display would sometimes flash black between songs instead of keeping the cover art up. Implemented a timer to fix this issue. Also added another timer to display a volume bar at the bottom when the volume on the airplay device is changed. 